### PR TITLE
Fix the issue caused by outdate HierarchicalUtils

### DIFF
--- a/src/Mill.jl
+++ b/src/Mill.jl
@@ -54,7 +54,7 @@ export replacein, findin
 include("hierarchical_utils.jl")
 
 Base.show(io::IO, ::T) where T <: Union{AbstractNode, AbstractMillModel, AggregationFunction} = show(io, Base.typename(T))
-Base.show(io::IO, ::MIME"text/plain", n::Union{AbstractNode, AbstractMillModel}) = HierarchicalUtils.printtree(io, n; trunc=3)
+Base.show(io::IO, ::MIME"text/plain", n::Union{AbstractNode, AbstractMillModel}) = HierarchicalUtils.printtree(io, n)
 Base.getindex(n::Union{AbstractNode, AbstractMillModel}, i::AbstractString) = HierarchicalUtils.walk(n, i)
 
 include("partialeval.jl")


### PR DESCRIPTION
When I use MILL in julia notebook, I meet such problem after defining a model:
```
# create the model
model = BagModel(
    ArrayModel(Dense(166, 10, Flux.tanh)),                      # model on the level of Flows
    SegmentedMeanMax(10),                                       # aggregation
    ArrayModel(Chain(Dense(20, 10, Flux.tanh), Dense(10, 2))))  # model on the level of bags
```
The raised error:
```
MethodError: no method matching printtree(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::BagModel{…}; trunc=3)
Closest candidates are:
  printtree(::IO, ::Any; trav, trunc_level) at /home/zhangzhi/.juliapro/JuliaPro_v1.4.1-1/packages/HierarchicalUtils/zPer6/src/printing.jl:39 got unsupported keyword argument "trunc"
  printtree(::Any; trav, trunc_level) at /home/zhangzhi/.juliapro/JuliaPro_v1.4.1-1/packages/HierarchicalUtils/zPer6/src/printing.jl:38 got unsupported keyword argument "trunc"
```
It is due to the fact that after running a cell, printtree is auto called to display the model. And I found that the version of released HierarchicalUtils (i.e., the user-installed version) is 0.0.7. Only after [this commit](https://github.com/Sheemon7/HierarchicalUtils.jl/commit/3595b87fed5b3d4ec7ced57f4853707ae104e0e9#diff-438d6ea8f2c3a79e28d778c363dd052b), the keyword `trunc_level` is updated to `trunc`.  In the 0.0.7 version, the keyword should be `trunc_level`. So I highly recommend using a default parameter to permits the work in both versions.